### PR TITLE
Add a setting to specify the API base url to support Mailgun regions.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Release Notes for Mailgun for Craft CMS
 
+## Unreleased
+
+### Added
+- Added an “Endpoint” setting, making it possible to use regional Mailgun API endpoint URLs. ([#4](https://github.com/craftcms/mailgun/pull/4))
+
 ## 1.2.0 - 2017-12-18
 
 ### Changed

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-  "name": "justdoweb-be/mailgun",
+  "name": "craftcms/mailgun",
   "description": "Mailgun integration for Craft CMS",
   "version": "1.2.0",
   "type": "craft-plugin",

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-  "name": "craftcms/mailgun",
+  "name": "justdoweb-be/mailgun",
   "description": "Mailgun integration for Craft CMS",
   "version": "1.2.0",
   "type": "craft-plugin",

--- a/src/MailgunAdapter.php
+++ b/src/MailgunAdapter.php
@@ -46,6 +46,11 @@ class MailgunAdapter extends BaseTransportAdapter
      */
     public $apiKey;
 
+    /**
+     * @var string The API key that should be used
+     */
+    public $apiBaseUrl;
+
     // Public Methods
     // =========================================================================
 
@@ -57,6 +62,7 @@ class MailgunAdapter extends BaseTransportAdapter
         return [
             'apiKey' => Craft::t('mailgun', 'API Key'),
             'domain' => Craft::t('mailgun', 'Domain'),
+            'apiBaseUrl' => Craft::t('mailgun', 'API Base Url'),
         ];
     }
 
@@ -66,7 +72,7 @@ class MailgunAdapter extends BaseTransportAdapter
     public function rules()
     {
         return [
-            [['apiKey', 'domain'], 'required'],
+            [['apiKey', 'domain', 'apiBaseUrl'], 'required'],
         ];
     }
 
@@ -88,6 +94,7 @@ class MailgunAdapter extends BaseTransportAdapter
         $guzzleClient = Craft::createGuzzleClient();
         $client = new Client($guzzleClient);
         $httpClientConfigurator = (new HttpClientConfigurator())
+            ->setEndpoint($this->apiBaseUrl)
             ->setHttpClient($client)
             ->setApiKey($this->apiKey);
 

--- a/src/MailgunAdapter.php
+++ b/src/MailgunAdapter.php
@@ -47,9 +47,9 @@ class MailgunAdapter extends BaseTransportAdapter
     public $apiKey;
 
     /**
-     * @var string The API key that should be used
+     * @var string The API endpoint that should be used
      */
-    public $apiBaseUrl;
+    public $endpoint;
 
     // Public Methods
     // =========================================================================
@@ -62,7 +62,7 @@ class MailgunAdapter extends BaseTransportAdapter
         return [
             'apiKey' => Craft::t('mailgun', 'API Key'),
             'domain' => Craft::t('mailgun', 'Domain'),
-            'apiBaseUrl' => Craft::t('mailgun', 'API Base Url'),
+            'endpoint' => Craft::t('mailgun', 'Endpoint'),
         ];
     }
 
@@ -72,7 +72,8 @@ class MailgunAdapter extends BaseTransportAdapter
     public function rules()
     {
         return [
-            [['apiKey', 'domain', 'apiBaseUrl'], 'required'],
+            [['apiKey', 'domain'], 'required'],
+            [['endpoint'], 'url', 'defaultScheme' => 'https'],
         ];
     }
 
@@ -94,9 +95,12 @@ class MailgunAdapter extends BaseTransportAdapter
         $guzzleClient = Craft::createGuzzleClient();
         $client = new Client($guzzleClient);
         $httpClientConfigurator = (new HttpClientConfigurator())
-            ->setEndpoint($this->apiBaseUrl)
             ->setHttpClient($client)
             ->setApiKey($this->apiKey);
+
+        if ($this->endpoint) {
+            $httpClientConfigurator->setEndpoint($this->endpoint);
+        }
 
         return [
             'class' => MailgunTransport::class,

--- a/src/templates/settings.html
+++ b/src/templates/settings.html
@@ -1,6 +1,7 @@
 {% import "_includes/forms" as forms %}
 
 {{ forms.textField({
+    required: true,
     label: "Domain"|t('mailgun'),
     instructions: "The domain to send email from."|t('mailgun'),
     id: 'domain',
@@ -10,6 +11,7 @@
 }) }}
 
 {{ forms.textField({
+    required: true,
     label: "API Key"|t('mailgun'),
     instructions: "You can find this in your Mailgun settings for the chosen domain."|t('mailgun'),
     id: 'apiKey',
@@ -19,10 +21,11 @@
 }) }}
 
 {{ forms.textField({
-    label: "API Base URL"|t('mailgun'),
-    instructions: "Include your domain with the url (ex: https://api.eu.mailgun.net/v3/mydomain). You can find this in your Mailgun settings for the chosen domain. The API url depends of the choosen region in Mailgun"|t('mailgun'),
-    id: 'apiBaseUrl',
-    name: 'apiBaseUrl',
-    value: adapter.apiBaseUrl,
-    errors: adapter.getErrors('apiBaseUrl')
+    label: "Endpoint"|t('mailgun'),
+    instructions: "You can find this in your Mailgun settings for the chosen domain."|t('mailgun'),
+    id: 'endpoint',
+    name: 'endpoint',
+    placeholder: 'https://api.mailgun.net',
+    value: adapter.endpoint,
+    errors: adapter.getErrors('endpoint')
 }) }}

--- a/src/templates/settings.html
+++ b/src/templates/settings.html
@@ -17,3 +17,12 @@
     value: adapter.apiKey,
     errors: adapter.getErrors('apiKey')
 }) }}
+
+{{ forms.textField({
+    label: "API Base URL"|t('mailgun'),
+    instructions: "Include your domain with the url (ex: https://api.eu.mailgun.net/v3/mydomain). You can find this in your Mailgun settings for the chosen domain. The API url depends of the choosen region in Mailgun"|t('mailgun'),
+    id: 'apiBaseUrl',
+    name: 'apiBaseUrl',
+    value: adapter.apiBaseUrl,
+    errors: adapter.getErrors('apiBaseUrl')
+}) }}


### PR DESCRIPTION
I have made some change in the plugin to support Mailgun regions. Users can specify the API base url in a textfield.