### PR TITLE
fix deprecated instructions in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ cd /path/to/my-project.test
 composer require craftcms/mailgun
 
 # tell Craft to install the plugin
-./craft install/plugin mailgun
+./craft plugin/install mailgun
 ```
 
 ## Setup


### PR DESCRIPTION
### Description

Before

```
php ./craft install/plugin mailgun

                                                 
    The install/plugin command is deprecated.    
        Running plugin/install instead...        
                                                 

*** installing mailgun
*** installed mailgun successfully (time: 0.014s)
```


After
```
php ./craft plugin/install mailgun

*** installing mailgun
*** installed mailgun successfully (time: 0.000s)
```

